### PR TITLE
Integrated TypeScript v2.x to be used for building protractor-numerator e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,6 @@ expect(listItemTwentieth.getText()).toBe('Twentieth');
 ```
 
 ## Thanks
-If this script was helpful for you, please give it a **★ Star** on
+If this plugin was helpful for you, please give it a **★ Star** on
 [Github](https://github.com/Marketionist/protractor-numerator) and
 [npm](https://www.npmjs.com/package/protractor-numerator)

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { ElementFinder } from 'protractor';
 
 // #############################################################################
 
-export let numerator = {
+export const numerator = {
 
     /**
      * Get the second matching element for the ElementArrayFinder. This does not

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/Marketionist/protractor-numerator#readme",
   "devDependencies": {
+    "@types/jasmine": "^2.5.43",
     "eslint": "^3.14.0",
     "node-testing-server": "^1.1.0",
     "protractor": "^5.0.0",

--- a/test/spec.ts
+++ b/test/spec.ts
@@ -1,6 +1,10 @@
 'use strict';
 
-let nodeTestingServer = require('node-testing-server').nodeTestingServer;
+import {} from 'jasmine';
+import { browser, element, by } from 'protractor';
+const nodeTestingServer = require('node-testing-server').nodeTestingServer;
+
+/* eslint spaced-comment: 1, eol-last: 1, quotes: 1, max-len:1, newline-after-var: 0 */
 
 // Settings for node testing server
 nodeTestingServer.config = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,
+        "removeComments": false,
+        "noImplicitAny": true,
         "lib": [
             "es2016"
         ],


### PR DESCRIPTION
**This pull request integrates TypeScript v2.x to be used for building protractor-numerator e2e tests**

Details:
- added _@types/jasmine_ to package.json
- updated tsconfig.json for more strict typing
- changed test/spec.js -> test/spec.ts
- updated README.md script -> plugin

Fixes https://github.com/Marketionist/protractor-numerator/issues/16